### PR TITLE
Fix light/dark themes and Heroku search highlighting

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,6 +1,3 @@
-/*
-Copyright © 2025 NAME HERE <EMAIL ADDRESS>
-*/
 package cmd
 
 import (
@@ -101,7 +98,7 @@ func createSplashHeader() string {
 
 	subtitle := lipgloss.NewStyle().
 		Bold(true).
-		Render("  Add color to your logs. No config | Just pipe")
+		Render("  Add color to your logs")
 
 	return header + "\n" + subtitle + "\n"
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,6 +1,5 @@
 /*
 Copyright © 2025 NAME HERE <EMAIL ADDRESS>
-
 */
 package cmd
 
@@ -14,9 +13,9 @@ import (
 	"syscall"
 
 	"github.com/charmbracelet/lipgloss"
-	"github.com/muesli/termenv"
 	"github.com/joshi4/splash/colorizer"
 	"github.com/joshi4/splash/parser"
+	"github.com/muesli/termenv"
 	"github.com/spf13/cobra"
 )
 
@@ -32,7 +31,7 @@ var (
 // createSplashHeader creates a colorful SPLASH header using log colors
 func createSplashHeader() string {
 	theme := colorizer.NewAdaptiveTheme()
-	
+
 	// ASCII art for SPLASH using block characters - each letter is 5 lines tall
 	sArt := []string{
 		"█████",
@@ -41,7 +40,7 @@ func createSplashHeader() string {
 		"    █",
 		"█████",
 	}
-	
+
 	pArt := []string{
 		"█████",
 		"█   █",
@@ -49,7 +48,7 @@ func createSplashHeader() string {
 		"█    ",
 		"█    ",
 	}
-	
+
 	lArt := []string{
 		"█    ",
 		"█    ",
@@ -57,7 +56,7 @@ func createSplashHeader() string {
 		"█    ",
 		"█████",
 	}
-	
+
 	aArt := []string{
 		" ███ ",
 		"█   █",
@@ -65,7 +64,7 @@ func createSplashHeader() string {
 		"█   █",
 		"█   █",
 	}
-	
+
 	s2Art := []string{
 		"█████",
 		"█    ",
@@ -73,7 +72,7 @@ func createSplashHeader() string {
 		"    █",
 		"█████",
 	}
-	
+
 	hArt := []string{
 		"█   █",
 		"█   █",
@@ -81,42 +80,42 @@ func createSplashHeader() string {
 		"█   █",
 		"█   █",
 	}
-	
+
 	// Combine all letters with colors
 	var lines []string
 	for i := 0; i < 5; i++ {
 		line := "  " +
-			theme.Error.Render(sArt[i]) + " " +      // Red
-			theme.Warning.Render(pArt[i]) + " " +    // Yellow
-			theme.Info.Render(lArt[i]) + " " +       // Cyan
-			theme.StatusOK.Render(aArt[i]) + " " +   // Green
-			theme.IP.Render(s2Art[i]) + " " +        // Blue
-			theme.Method.Render(hArt[i])             // Pink
+			theme.Error.Render(sArt[i]) + " " + // Red
+			theme.Warning.Render(pArt[i]) + " " + // Yellow
+			theme.Info.Render(lArt[i]) + " " + // Cyan
+			theme.StatusOK.Render(aArt[i]) + " " + // Green
+			theme.IP.Render(s2Art[i]) + " " + // Blue
+			theme.Method.Render(hArt[i]) // Pink
 		lines = append(lines, line)
 	}
-	
+
 	header := "\n"
 	for _, line := range lines {
 		header += line + "\n"
 	}
-	
+
 	subtitle := lipgloss.NewStyle().
 		Bold(true).
-		Render("  Add color to your logs")
-		
+		Render("  Add color to your logs. No config | Just pipe")
+
 	return header + "\n" + subtitle + "\n"
 }
 
 // createColorizerWithTheme creates a colorizer with proper theme detection
 func createColorizerWithTheme() *colorizer.Colorizer {
 	c := colorizer.NewColorizer()
-	
+
 	// Handle explicit theme flags
 	if lightTheme && darkTheme {
 		fmt.Fprintf(os.Stderr, "Cannot use both --light and --dark flags simultaneously\n")
 		os.Exit(1)
 	}
-	
+
 	if lightTheme {
 		// Force light theme colors by setting the colorizer to use light theme
 		c.SetTheme(colorizer.NewLightTheme())
@@ -125,7 +124,7 @@ func createColorizerWithTheme() *colorizer.Colorizer {
 		c.SetTheme(colorizer.NewDarkTheme())
 	}
 	// Otherwise use default adaptive theme
-	
+
 	return c
 }
 
@@ -158,7 +157,7 @@ func runSplash() {
 		// This ensures colors work when doing: echo "log" | splash | less -R
 		lipgloss.SetColorProfile(termenv.TrueColor)
 	}
-	
+
 	// Create a context that will be cancelled when we receive a signal
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -169,21 +168,20 @@ func runSplash() {
 
 	// Start a goroutine to handle signals
 	go func() {
-		sig := <-sigChan
-		fmt.Fprintf(os.Stderr, "\nReceived signal: %v, shutting down gracefully...\n", sig)
+		<-sigChan
 		cancel()
 	}()
 
 	// Create optimized parser and colorizer with theme detection
 	logParser := parser.NewParser()
 	logColorizer := createColorizerWithTheme()
-	
+
 	// Set search patterns if provided
 	if searchPattern != "" && regexPattern != "" {
 		fmt.Fprintf(os.Stderr, "Cannot use both --search and --regexp flags simultaneously\n")
 		os.Exit(1)
 	}
-	
+
 	if searchPattern != "" {
 		logColorizer.SetSearchString(searchPattern)
 	} else if regexPattern != "" {
@@ -196,10 +194,10 @@ func runSplash() {
 
 	// Read from stdin and write to stdout
 	scanner := bufio.NewScanner(os.Stdin)
-	
+
 	// Channel to signal when reading is done
 	done := make(chan bool)
-	
+
 	go func() {
 		defer close(done)
 		for scanner.Scan() {
@@ -215,13 +213,13 @@ func runSplash() {
 				fmt.Println(colorizedLine)
 			}
 		}
-		
+
 		// Check for scanner errors
 		if err := scanner.Err(); err != nil && err != io.EOF {
 			fmt.Fprintf(os.Stderr, "Error reading from stdin: %v\n", err)
 		}
 	}()
-	
+
 	// Wait for either the context to be cancelled or reading to complete
 	select {
 	case <-ctx.Done():
@@ -235,11 +233,9 @@ func init() {
 	// Search flags
 	rootCmd.Flags().StringVarP(&searchPattern, "search", "s", "", "highlight matching text in a log line")
 	rootCmd.Flags().StringVarP(&regexPattern, "regexp", "r", "", "highlight text that matches a regexp per log line")
-	
+
 	// Theme flags
 	rootCmd.Flags().BoolVar(&lightTheme, "light", false, "force light theme colors (for light terminal backgrounds)")
 	rootCmd.Flags().BoolVar(&darkTheme, "dark", false, "force dark theme colors (for dark terminal backgrounds)")
 	rootCmd.Flags().BoolVar(&noColor, "no-color", false, "disable all colors")
 }
-
-

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -129,7 +129,7 @@ func createColorizerWithTheme() *colorizer.Colorizer {
 var rootCmd = &cobra.Command{
 	Use:   "splash",
 	Short: "Add color to your logs",
-	Long:  createSplashHeader() + "\nSplash transforms streams of boring plaintext into colorful and easy to read logs.\n\nSupported formats: JSON, Logfmt, Syslog, Apache, Nginx, Rails, Docker,\nKubernetes, Heroku, Go standard logs, and more.",
+	Long:  createSplashHeader() + "\nSplash transforms streams of boring plaintext into colorful and easy to read logs.\nUse Splash to easily scan and debug issues from your logs.\n\nSupported formats: JSON, Logfmt, Syslog, Apache, Nginx, Rails, Docker,\nKubernetes, Heroku, Go standard logs, and more.",
 	Example: `  tail -f /var/log/app.log | splash
   docker logs mycontainer | splash
   kubectl logs pod-name | splash -s "ERROR"

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -132,7 +132,11 @@ func createColorizerWithTheme() *colorizer.Colorizer {
 var rootCmd = &cobra.Command{
 	Use:   "splash",
 	Short: "Add color to your logs",
-	Long:  createSplashHeader() + "\nSplash streams logs from stdin to stdout, auto-detecting well-known log formats\nand adding colors to make them easier to parse and scan.\n\nSupported formats: JSON, Logfmt, Syslog, Apache, Nginx, Rails, Docker,\nKubernetes, Heroku, Go standard logs, and more.\n\nExamples:\n  tail -f /var/log/app.log | splash\n  docker logs mycontainer | splash\n  kubectl logs pod-name | splash -s \"ERROR\"\n  cat access.log | splash -r \"[45]\\d\\d\"",
+	Long:  createSplashHeader() + "\nSplash transforms streams of boring plaintext into colorful and easy to read logs.\n\nSupported formats: JSON, Logfmt, Syslog, Apache, Nginx, Rails, Docker,\nKubernetes, Heroku, Go standard logs, and more.",
+	Example: `  tail -f /var/log/app.log | splash
+  docker logs mycontainer | splash
+  kubectl logs pod-name | splash -s "ERROR"
+  cat access.log | splash -r "[45]\\d\\d"`,
 	Run: func(cmd *cobra.Command, args []string) {
 		runSplash()
 	},
@@ -231,8 +235,8 @@ func runSplash() {
 
 func init() {
 	// Search flags
-	rootCmd.Flags().StringVarP(&searchPattern, "search", "s", "", "highlight matching text in a log line")
-	rootCmd.Flags().StringVarP(&regexPattern, "regexp", "r", "", "highlight text that matches a regexp per log line")
+	rootCmd.Flags().StringVarP(&searchPattern, "search", "s", "", "search for all instances of a string")
+	rootCmd.Flags().StringVarP(&regexPattern, "regexp", "r", "", "search for text that matches a regexp")
 
 	// Theme flags
 	rootCmd.Flags().BoolVar(&lightTheme, "light", false, "force light theme colors (for light terminal backgrounds)")

--- a/colorizer/colorizer.go
+++ b/colorizer/colorizer.go
@@ -25,6 +25,11 @@ func NewColorizer() *Colorizer {
 	}
 }
 
+// SetTheme sets a custom theme for the colorizer
+func (c *Colorizer) SetTheme(theme *ColorTheme) {
+	c.theme = theme
+}
+
 // SetSearchString sets a literal string to search for and highlight
 func (c *Colorizer) SetSearchString(pattern string) {
 	c.searchString = pattern
@@ -528,21 +533,22 @@ func (c *Colorizer) colorizeApacheCommon(line string) string {
 	size := matches[9]
 	
 	result := strings.Builder{}
-	result.WriteString(c.applyStyleWithMarkers(ip, c.theme.IP))
+	// Apply search highlighting during colorization (single-pass)
+	result.WriteString(c.applySearchHighlighting(ip, c.theme.IP))
 	result.WriteString(" - - ")
 	result.WriteString(c.theme.Bracket.Render("["))
-	result.WriteString(c.applyStyleWithMarkers(timestamp, c.theme.Timestamp))
+	result.WriteString(c.applySearchHighlighting(timestamp, c.theme.Timestamp))
 	result.WriteString(c.theme.Bracket.Render("] "))
 	result.WriteString(c.theme.Quote.Render(`"`))
-	result.WriteString(c.applyStyleWithMarkers(method, c.theme.Method))
+	result.WriteString(c.applySearchHighlighting(method, c.theme.Method))
 	result.WriteString(" ")
-	result.WriteString(c.applyStyleWithMarkers(url, c.theme.URL))
+	result.WriteString(c.applySearchHighlighting(url, c.theme.URL))
 	result.WriteString(" ")
-	result.WriteString(protocol)
+	result.WriteString(c.applySearchHighlighting(protocol, lipgloss.NewStyle()))
 	result.WriteString(c.theme.Quote.Render(`" `))
-	result.WriteString(c.applyStyleWithMarkers(status, c.theme.GetHTTPStatusStyle(status)))
+	result.WriteString(c.applySearchHighlighting(status, c.theme.GetHTTPStatusStyle(status)))
 	result.WriteString(" ")
-	result.WriteString(size)
+	result.WriteString(c.applySearchHighlighting(size, lipgloss.NewStyle()))
 	
 	return result.String()
 }
@@ -568,26 +574,27 @@ func (c *Colorizer) colorizeNginx(line string) string {
 	userAgent := matches[11]
 	
 	result := strings.Builder{}
-	result.WriteString(c.applyStyleWithMarkers(ip, c.theme.IP))
+	// Apply search highlighting during colorization (single-pass)
+	result.WriteString(c.applySearchHighlighting(ip, c.theme.IP))
 	result.WriteString(" - - ")
 	result.WriteString(c.theme.Bracket.Render("["))
-	result.WriteString(c.applyStyleWithMarkers(timestamp, c.theme.Timestamp))
+	result.WriteString(c.applySearchHighlighting(timestamp, c.theme.Timestamp))
 	result.WriteString(c.theme.Bracket.Render("] "))
 	result.WriteString(c.theme.Quote.Render(`"`))
-	result.WriteString(c.applyStyleWithMarkers(method, c.theme.Method))
+	result.WriteString(c.applySearchHighlighting(method, c.theme.Method))
 	result.WriteString(" ")
-	result.WriteString(c.applyStyleWithMarkers(url, c.theme.URL))
+	result.WriteString(c.applySearchHighlighting(url, c.theme.URL))
 	result.WriteString(" ")
-	result.WriteString(protocol)
+	result.WriteString(c.applySearchHighlighting(protocol, lipgloss.NewStyle()))
 	result.WriteString(c.theme.Quote.Render(`" `))
-	result.WriteString(c.applyStyleWithMarkers(status, c.theme.GetHTTPStatusStyle(status)))
+	result.WriteString(c.applySearchHighlighting(status, c.theme.GetHTTPStatusStyle(status)))
 	result.WriteString(" ")
-	result.WriteString(size)
+	result.WriteString(c.applySearchHighlighting(size, lipgloss.NewStyle()))
 	result.WriteString(" ")
 	result.WriteString(c.theme.Quote.Render(`"`))
-	result.WriteString(referer)
+	result.WriteString(c.applySearchHighlighting(referer, lipgloss.NewStyle()))
 	result.WriteString(c.theme.Quote.Render(`" "`))
-	result.WriteString(userAgent)
+	result.WriteString(c.applySearchHighlighting(userAgent, lipgloss.NewStyle()))
 	result.WriteString(c.theme.Quote.Render(`"`))
 	
 	return result.String()
@@ -633,15 +640,16 @@ func (c *Colorizer) colorizeSyslog(line string) string {
 	message := matches[5]
 	
 	result := strings.Builder{}
-	result.WriteString(c.applyStyleWithMarkers(timestamp, c.theme.Timestamp))
+	// Apply search highlighting during colorization (single-pass)
+	result.WriteString(c.applySearchHighlighting(timestamp, c.theme.Timestamp))
 	result.WriteString(" ")
-	result.WriteString(c.applyStyleWithMarkers(hostname, c.theme.Hostname))
+	result.WriteString(c.applySearchHighlighting(hostname, c.theme.Hostname))
 	result.WriteString(" ")
-	result.WriteString(c.applyStyleWithMarkers(process, c.theme.Service))
+	result.WriteString(c.applySearchHighlighting(process, c.theme.Service))
 	result.WriteString(c.theme.Bracket.Render("["))
-	result.WriteString(c.applyStyleWithMarkers(pid, c.theme.PID))
+	result.WriteString(c.applySearchHighlighting(pid, c.theme.PID))
 	result.WriteString(c.theme.Bracket.Render("]: "))
-	result.WriteString(c.colorizeMessage(message))
+	result.WriteString(c.colorizeMessageWithHighlighting(message))
 	
 	return result.String()
 }
@@ -684,13 +692,14 @@ func (c *Colorizer) colorizeRails(line string) string {
 		result := strings.Builder{}
 		result.WriteString(c.theme.Bracket.Render("["))
 		timestampContent := timestamp[1:len(timestamp)-1] // Remove brackets
-		result.WriteString(c.applyStyleWithMarkers(timestampContent, c.theme.Timestamp))
+		// Apply search highlighting during colorization (single-pass)
+		result.WriteString(c.applySearchHighlighting(timestampContent, c.theme.Timestamp))
 		result.WriteString(c.theme.Bracket.Render("] "))
-		result.WriteString(c.applyStyleWithMarkers(level, c.theme.GetLogLevelStyle(level)))
+		result.WriteString(c.applySearchHighlighting(level, c.theme.GetLogLevelStyle(level)))
 		result.WriteString(" ")
-		result.WriteString(separator)
+		result.WriteString(c.applySearchHighlighting(separator, lipgloss.NewStyle()))
 		result.WriteString(" : ")
-		result.WriteString(message)
+		result.WriteString(c.applySearchHighlighting(message, lipgloss.NewStyle()))
 		
 		return result.String()
 	}
@@ -707,11 +716,12 @@ func (c *Colorizer) colorizeRails(line string) string {
 		result := strings.Builder{}
 		result.WriteString(c.theme.Bracket.Render("["))
 		timestampContent := timestamp[1:len(timestamp)-1] // Remove brackets
-		result.WriteString(c.applyStyleWithMarkers(timestampContent, c.theme.Timestamp))
+		// Apply search highlighting during colorization (single-pass)
+		result.WriteString(c.applySearchHighlighting(timestampContent, c.theme.Timestamp))
 		result.WriteString(c.theme.Bracket.Render("] "))
-		result.WriteString(c.applyStyleWithMarkers(level, c.theme.GetLogLevelStyle(level)))
+		result.WriteString(c.applySearchHighlighting(level, c.theme.GetLogLevelStyle(level)))
 		result.WriteString(" ")
-		result.WriteString(c.applyStyleWithMarkers(message, c.theme.JSONValue))
+		result.WriteString(c.applySearchHighlighting(message, c.theme.JSONValue))
 		
 		return result.String()
 	}
@@ -759,15 +769,16 @@ func (c *Colorizer) colorizeKubernetes(line string) string {
 	message := matches[5]
 	
 	result := strings.Builder{}
-	result.WriteString(c.applyStyleWithMarkers(timestamp, c.theme.Timestamp))
+	// Apply search highlighting during colorization (single-pass)
+	result.WriteString(c.applySearchHighlighting(timestamp, c.theme.Timestamp))
 	result.WriteString(" ")
-	result.WriteString(c.applyStyleWithMarkers(severity, c.theme.PID))
+	result.WriteString(c.applySearchHighlighting(severity, c.theme.PID))
 	result.WriteString(" ")
-	result.WriteString(c.applyStyleWithMarkers(filename, c.theme.Filename))
+	result.WriteString(c.applySearchHighlighting(filename, c.theme.Filename))
 	result.WriteString(":")
-	result.WriteString(c.applyStyleWithMarkers(lineNum, c.theme.LineNum))
+	result.WriteString(c.applySearchHighlighting(lineNum, c.theme.LineNum))
 	result.WriteString(c.theme.Bracket.Render("] "))
-	result.WriteString(c.colorizeMessage(message))
+	result.WriteString(c.colorizeMessageWithHighlighting(message))
 	
 	return result.String()
 }
@@ -786,12 +797,13 @@ func (c *Colorizer) colorizeHeroku(line string) string {
 	message := matches[3]
 	
 	result := strings.Builder{}
-	result.WriteString(c.theme.Timestamp.Render(timestamp))
+	// Apply search highlighting during colorization (single-pass)
+	result.WriteString(c.applySearchHighlighting(timestamp, c.theme.Timestamp))
 	result.WriteString(" app")
 	result.WriteString(c.theme.Bracket.Render("["))
-	result.WriteString(c.theme.Service.Render(dyno))
+	result.WriteString(c.applySearchHighlighting(dyno, c.theme.Service))
 	result.WriteString(c.theme.Bracket.Render("]: "))
-	result.WriteString(c.colorizeMessage(message))
+	result.WriteString(c.colorizeMessageWithHighlighting(message))
 	
 	return result.String()
 }

--- a/colorizer/themes.go
+++ b/colorizer/themes.go
@@ -56,46 +56,46 @@ type ColorTheme struct {
 // NewAdaptiveTheme creates a color theme that adapts to the terminal
 func NewAdaptiveTheme() *ColorTheme {
 	return &ColorTheme{
-		// Log levels with semantic colors using adaptive ANSI colors
-		Error:   lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "#D63031", Dark: "#FF6B6B"}).Bold(true), // Red
-		Warning: lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "#E17000", Dark: "#FFE66D"}),             // Yellow
-		Info:    lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "#00B894", Dark: "#4ECDC4"}),             // Cyan
-		Debug:   lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "#00A085", Dark: "#95E1D3"}),             // Light green
+		// Log levels with semantic colors using ANSI colors for better compatibility
+		Error:   lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "1", Dark: "9"}).Bold(true),   // Red/Bright red
+		Warning: lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "130", Dark: "11"}),             // Dark orange for light, bright yellow for dark
+		Info:    lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "4", Dark: "14"}),             // Blue/Bright cyan
+		Debug:   lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "2", Dark: "10"}),             // Green/Bright green
 		
 		// HTTP status codes
-		StatusOK:    lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "#00B894", Dark: "#6BCF7F"}),         // Green
-		StatusWarn:  lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "#E17000", Dark: "#FFD93D"}),         // Yellow
-		StatusError: lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "#D63031", Dark: "#FF6B6B"}).Bold(true), // Red
+		StatusOK:    lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "2", Dark: "10"}),         // Green/Bright green
+		StatusWarn:  lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "130", Dark: "11"}),         // Dark orange for light, bright yellow for dark
+		StatusError: lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "1", Dark: "9"}).Bold(true), // Red/Bright red
 		
-		// General components
-		Timestamp: lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "#636E72", Dark: "#A8A8A8"}),           // Gray
-		IP:        lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "#0984E3", Dark: "#74B9FF"}),           // Blue
-		URL:       lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "#00CEC9", Dark: "#81ECEC"}).Underline(true), // Cyan underlined
-		Method:    lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "#E84393", Dark: "#FD79A8"}).Bold(true), // Pink
+		// General components - ANSI colors for better compatibility
+		Timestamp: lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "8", Dark: "245"}),         // Bright black/Medium gray
+		IP:        lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "4", Dark: "12"}).Bold(true), // Blue/Bright blue
+		URL:       lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "6", Dark: "14"}).Underline(true), // Cyan/Bright cyan
+		Method:    lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "5", Dark: "13"}).Bold(true), // Magenta/Bright magenta
 		
-		// JSON/structured data
-		JSONKey:    lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "#8E44AD", Dark: "#DDA0DD"}),          // Plum
-		JSONValue:  lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "#2D3436", Dark: "#F0F0F0"}),          // Light gray
-		JSONString: lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "#00A085", Dark: "#98FB98"}),          // Pale green
-		JSONNumber: lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "#0984E3", Dark: "#87CEEB"}),          // Sky blue
+		// JSON/structured data - ANSI colors for better compatibility
+		JSONKey:    lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "5", Dark: "13"}).Bold(true), // Magenta/Bright magenta
+		JSONValue:  lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "0", Dark: "7"}),           // Black/White
+		JSONString: lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "2", Dark: "10"}),          // Green/Bright green
+		JSONNumber: lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "4", Dark: "12"}),          // Blue/Bright blue
 		
 		// Logfmt
-		LogfmtKey:   lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "#8E44AD", Dark: "#DDA0DD"}),         // Plum
-		LogfmtValue: lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "#2D3436", Dark: "#F0F0F0"}),         // Light gray
+		LogfmtKey:   lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "5", Dark: "13"}).Bold(true), // Magenta/Bright magenta
+		LogfmtValue: lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "0", Dark: "7"}),           // Black/White
 		
-		// System/process info
-		Hostname: lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "#E17000", Dark: "#FFB347"}),            // Peach
-		PID:      lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "#6C5CE7", Dark: "#B19CD9"}),            // Lavender
-		Service:  lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "#0984E3", Dark: "#87CEEB"}).Bold(true), // Sky blue
+		// System/process info - ANSI colors for better compatibility
+		Hostname: lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "3", Dark: "11"}).Bold(true), // Yellow/Bright yellow
+		PID:      lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "5", Dark: "13"}),            // Magenta/Bright magenta
+		Service:  lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "4", Dark: "12"}).Bold(true), // Blue/Bright blue
 		
 		// File references
-		Filename: lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "#E17000", Dark: "#FFA07A"}),            // Light salmon
-		LineNum:  lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "#6C5CE7", Dark: "#B19CD9"}),            // Lavender
+		Filename: lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "3", Dark: "11"}),            // Yellow/Bright yellow
+		LineNum:  lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "5", Dark: "13"}),            // Magenta/Bright magenta
 		
-		// Punctuation/structure (subtle)
-		Bracket: lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "#636E72", Dark: "#808080"}),             // Gray
-		Quote:   lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "#636E72", Dark: "#808080"}),             // Gray
-		Equals:  lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "#636E72", Dark: "#808080"}),             // Gray
+		// Punctuation/structure (subtle but visible)
+		Bracket: lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "8", Dark: "8"}),             // Bright black/Bright black
+		Quote:   lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "8", Dark: "8"}),             // Bright black/Bright black
+		Equals:  lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "8", Dark: "8"}),             // Bright black/Bright black
 		
 		// Search highlighting (bold text, no background)
 		SearchHighlight: lipgloss.NewStyle().
@@ -103,16 +103,123 @@ func NewAdaptiveTheme() *ColorTheme {
 		
 		// JSON-specific search highlighting with high visibility foreground colors
 		JSONSearchHighlight: lipgloss.NewStyle().
-			Foreground(lipgloss.AdaptiveColor{Light: "#E17000", Dark: "#FFA500"}).  // Orange: dark orange for light theme, bright orange for dark theme
-			Bold(true),                                                              // Bold for extra visibility
-		// Alternative options (comment/uncomment to change):
-		// Red variant:    Foreground(lipgloss.AdaptiveColor{Light: "#D63031", Dark: "#FF6B6B"}).Bold(true)
-		// Yellow variant: Foreground(lipgloss.AdaptiveColor{Light: "#B8860B", Dark: "#FFFF00"}).Bold(true)
+			Foreground(lipgloss.AdaptiveColor{Light: "3", Dark: "11"}).  // Yellow: ANSI yellow for light, bright yellow for dark
+			Bold(true),                                                   // Bold for extra visibility
 		
-		// Unified search highlighting - Bright Orange + Adaptive (replaces above styles)
+		// Unified search highlighting - Yellow background for light, orange background for dark
 		UnifiedSearchHighlight: lipgloss.NewStyle().
-			Background(lipgloss.AdaptiveColor{Light: "#FB923C", Dark: "#DC2626"}).
-			Foreground(lipgloss.AdaptiveColor{Light: "#000000", Dark: "#FEF3C7"}).
+			Background(lipgloss.AdaptiveColor{Light: "3", Dark: "208"}).      // Yellow for light, orange for dark  
+			Foreground(lipgloss.AdaptiveColor{Light: "1", Dark: "0"}).        // Red text for light, black for dark
+			Bold(true),
+	}
+}
+
+// NewLightTheme creates a theme optimized for light terminal backgrounds
+func NewLightTheme() *ColorTheme {
+	return &ColorTheme{
+		// Log levels with darker ANSI colors for light backgrounds
+		Error:   lipgloss.NewStyle().Foreground(lipgloss.Color("1")).Bold(true),  // ANSI red
+		Warning: lipgloss.NewStyle().Foreground(lipgloss.Color("130")).Bold(true), // ANSI dark orange (darker than yellow)
+		Info:    lipgloss.NewStyle().Foreground(lipgloss.Color("4")).Bold(true),  // ANSI blue
+		Debug:   lipgloss.NewStyle().Foreground(lipgloss.Color("2")).Bold(true),  // ANSI green
+		
+		// HTTP status codes
+		StatusOK:    lipgloss.NewStyle().Foreground(lipgloss.Color("2")).Bold(true),  // ANSI green
+		StatusWarn:  lipgloss.NewStyle().Foreground(lipgloss.Color("130")).Bold(true),  // ANSI dark orange
+		StatusError: lipgloss.NewStyle().Foreground(lipgloss.Color("1")).Bold(true),  // ANSI red
+		
+		// General components - darker ANSI colors for light themes
+		Timestamp: lipgloss.NewStyle().Foreground(lipgloss.Color("8")),               // ANSI bright black
+		IP:        lipgloss.NewStyle().Foreground(lipgloss.Color("4")).Bold(true),    // ANSI blue
+		URL:       lipgloss.NewStyle().Foreground(lipgloss.Color("6")).Underline(true), // ANSI cyan underlined
+		Method:    lipgloss.NewStyle().Foreground(lipgloss.Color("5")).Bold(true),    // ANSI magenta
+		
+		// JSON/structured data
+		JSONKey:    lipgloss.NewStyle().Foreground(lipgloss.Color("5")).Bold(true),   // ANSI magenta
+		JSONValue:  lipgloss.NewStyle().Foreground(lipgloss.Color("0")),              // ANSI black
+		JSONString: lipgloss.NewStyle().Foreground(lipgloss.Color("2")),              // ANSI green
+		JSONNumber: lipgloss.NewStyle().Foreground(lipgloss.Color("4")),              // ANSI blue
+		
+		// Logfmt
+		LogfmtKey:   lipgloss.NewStyle().Foreground(lipgloss.Color("5")).Bold(true),  // ANSI magenta
+		LogfmtValue: lipgloss.NewStyle().Foreground(lipgloss.Color("0")),             // ANSI black
+		
+		// System/process info
+		Hostname: lipgloss.NewStyle().Foreground(lipgloss.Color("3")).Bold(true),     // ANSI yellow
+		PID:      lipgloss.NewStyle().Foreground(lipgloss.Color("5")),                // ANSI magenta
+		Service:  lipgloss.NewStyle().Foreground(lipgloss.Color("4")).Bold(true),     // ANSI blue
+		
+		// File references
+		Filename: lipgloss.NewStyle().Foreground(lipgloss.Color("3")),                // ANSI yellow
+		LineNum:  lipgloss.NewStyle().Foreground(lipgloss.Color("5")),                // ANSI magenta
+		
+		// Punctuation/structure
+		Bracket: lipgloss.NewStyle().Foreground(lipgloss.Color("8")),                 // ANSI bright black
+		Quote:   lipgloss.NewStyle().Foreground(lipgloss.Color("8")),                 // ANSI bright black
+		Equals:  lipgloss.NewStyle().Foreground(lipgloss.Color("8")),                 // ANSI bright black
+		
+		// Search highlighting
+		SearchHighlight: lipgloss.NewStyle().Bold(true),
+		JSONSearchHighlight: lipgloss.NewStyle().
+			Foreground(lipgloss.Color("3")).Bold(true),   // ANSI yellow
+		UnifiedSearchHighlight: lipgloss.NewStyle().
+			Background(lipgloss.Color("3")).     // ANSI yellow background
+			Foreground(lipgloss.Color("1")).     // ANSI red text  
+			Bold(true),
+	}
+}
+
+// NewDarkTheme creates a theme optimized for dark terminal backgrounds
+func NewDarkTheme() *ColorTheme {
+	return &ColorTheme{
+		// Log levels with brighter colors for dark backgrounds
+		Error:   lipgloss.NewStyle().Foreground(lipgloss.Color("#FF6B6B")).Bold(true), // Bright red
+		Warning: lipgloss.NewStyle().Foreground(lipgloss.Color("#FFE66D")),             // Bright yellow
+		Info:    lipgloss.NewStyle().Foreground(lipgloss.Color("#4ECDC4")),             // Bright cyan
+		Debug:   lipgloss.NewStyle().Foreground(lipgloss.Color("#95E1D3")),             // Light green
+		
+		// HTTP status codes
+		StatusOK:    lipgloss.NewStyle().Foreground(lipgloss.Color("#6BCF7F")),         // Bright green
+		StatusWarn:  lipgloss.NewStyle().Foreground(lipgloss.Color("#FFD93D")),         // Bright yellow
+		StatusError: lipgloss.NewStyle().Foreground(lipgloss.Color("#FF6B6B")).Bold(true), // Bright red
+		
+		// General components
+		Timestamp: lipgloss.NewStyle().Foreground(lipgloss.Color("245")),               // ANSI medium gray (dimmed but visible)
+		IP:        lipgloss.NewStyle().Foreground(lipgloss.Color("#74B9FF")),           // Light blue
+		URL:       lipgloss.NewStyle().Foreground(lipgloss.Color("#81ECEC")).Underline(true), // Light cyan underlined
+		Method:    lipgloss.NewStyle().Foreground(lipgloss.Color("#FD79A8")).Bold(true), // Light pink
+		
+		// JSON/structured data
+		JSONKey:    lipgloss.NewStyle().Foreground(lipgloss.Color("#DDA0DD")),          // Light plum
+		JSONValue:  lipgloss.NewStyle().Foreground(lipgloss.Color("#F0F0F0")),          // Light gray
+		JSONString: lipgloss.NewStyle().Foreground(lipgloss.Color("#98FB98")),          // Light green
+		JSONNumber: lipgloss.NewStyle().Foreground(lipgloss.Color("#87CEEB")),          // Light blue
+		
+		// Logfmt
+		LogfmtKey:   lipgloss.NewStyle().Foreground(lipgloss.Color("#DDA0DD")),         // Light plum
+		LogfmtValue: lipgloss.NewStyle().Foreground(lipgloss.Color("#F0F0F0")),         // Light gray
+		
+		// System/process info
+		Hostname: lipgloss.NewStyle().Foreground(lipgloss.Color("#FFB347")),            // Light orange
+		PID:      lipgloss.NewStyle().Foreground(lipgloss.Color("#B19CD9")),            // Light lavender
+		Service:  lipgloss.NewStyle().Foreground(lipgloss.Color("#87CEEB")).Bold(true), // Light blue
+		
+		// File references
+		Filename: lipgloss.NewStyle().Foreground(lipgloss.Color("#FFA07A")),            // Light salmon
+		LineNum:  lipgloss.NewStyle().Foreground(lipgloss.Color("#B19CD9")),            // Light lavender
+		
+		// Punctuation/structure
+		Bracket: lipgloss.NewStyle().Foreground(lipgloss.Color("#808080")),             // Gray
+		Quote:   lipgloss.NewStyle().Foreground(lipgloss.Color("#808080")),             // Gray
+		Equals:  lipgloss.NewStyle().Foreground(lipgloss.Color("#808080")),             // Gray
+		
+		// Search highlighting
+		SearchHighlight: lipgloss.NewStyle().Bold(true),
+		JSONSearchHighlight: lipgloss.NewStyle().
+			Foreground(lipgloss.Color("#FFA500")).Bold(true),
+		UnifiedSearchHighlight: lipgloss.NewStyle().
+			Background(lipgloss.Color("214")).   // ANSI bright orange background  
+			Foreground(lipgloss.Color("0")).     // ANSI black text
 			Bold(true),
 	}
 }

--- a/main.go
+++ b/main.go
@@ -1,7 +1,3 @@
-/*
-Copyright © 2025 NAME HERE <EMAIL ADDRESS>
-
-*/
 package main
 
 import "github.com/joshi4/splash/cmd"


### PR DESCRIPTION
- Enhanced light theme colors for better visibility on light backgrounds:
  - Updated WARN level to use darker orange (ANSI 130) for better contrast
  - Converted most colors to ANSI codes for better terminal compatibility
  - Fixed search highlighting to use yellow background with red text

- Improved dark theme visibility:
  - Fixed timestamp color from too-dim bright black to medium gray (ANSI 245)
  - Updated search highlighting to use orange background with black text
  - Maintained proper contrast for all log levels

- Fixed broken search highlighting in Heroku log format:
  - Updated colorizeHeroku to use applySearchHighlighting for all components
  - Timestamps, dyno names, and messages now properly highlight search matches
  - Added comprehensive tests to prevent regression

- Added robust test coverage:
  - TestHerokuSearchHighlighting: Ensures search works across all Heroku components
  - TestDarkThemeTimestampStylingPreservation: Prevents styling loss during highlighting
  - TestDarkThemePreventTimestampStylingRegression: Comprehensive regression tests

All log formats now have consistent search highlighting behavior with properly
balanced timestamp colors for both light and dark terminal backgrounds.

Co-authored-by: Amp <amp@ampcode.com>
Amp-Thread-ID: https://ampcode.com/threads/T-ecceaff4-9286-48e7-8855-e4e8734974cd
